### PR TITLE
Fix empty energy selection crash

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -511,6 +511,10 @@ elif page == "Country Energy Mix":
         default=energy_cols[:5]
     )
 
+    if not selected_energy:
+        st.warning("Please select at least one energy source to display the energy mix.")
+        st.stop()
+
     # 📊 Average consumption for selected energy types
     avg_data = country_data[selected_energy].mean().sort_values(ascending=False)
     avg_df = avg_data.reset_index()


### PR DESCRIPTION
## Summary
- avoid crash when no energy sources are selected in country energy mix page

## Testing
- `python -m py_compile streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6840bab8ce288323ae9c7ddcbd2f2d17